### PR TITLE
Superb guide: If there's an error loading ssr code, dump the cache and try again on the next request

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -9,16 +9,6 @@ const [getFromCache, clearCache] = createCache(dayjs.convert(15, 'minutes', 'ms'
 
 const watch = (location, entry, verb) => {
   let logTiming = true;
-  const loadClient = () => {
-    const startTime = performance.now();
-    const required = require(entry);
-    const endTime = performance.now();
-    if (logTiming) {
-      console.log(`SSR ${verb} took ${Math.round(endTime - startTime)}ms`);
-      logTiming = false;
-    }
-    return required;
-  };
   const dumpClient = () => {
     // clear changed files from the require cache
     Object.keys(require.cache).forEach((file) => {
@@ -28,6 +18,21 @@ const watch = (location, entry, verb) => {
     clearCache();
     // we're reloading off the disc, so print out the perf info again
     logTiming = true;
+  };
+  const loadClient = () => {
+    try {
+      const startTime = performance.now();
+      const required = require(entry);
+      const endTime = performance.now();
+      if (logTiming) {
+        console.log(`SSR ${verb} took ${Math.round(endTime - startTime)}ms`);
+        logTiming = false;
+      }
+      return required;
+    } catch (error) {
+      dumpClient(); // don't get stuck on bad code if there's a race condition or something
+      throw error;
+    }
   };
   const watcher = require('chokidar').watch(location).on('ready', () => {
     // dump the client and ssr cache whenever the code changes, it'll reload on the next ssr render


### PR DESCRIPTION
## Links
https://superb-guide.glitch.me/
https://app.clubhouse.io/glitch/story/4531/typeerror-resetstate-is-not-a-function

## Changes:
Any error in the load client function will cause it to clear out the cache so that the next request will start fresh. My hope is that the resetState error happens because the initial require happened while webpack was still writing the file, and the node require cache is keeping it from trying again. This could backfire if the build file is actually broken, in which case the server will reload from scratch on every request.

## How To Test:
Set BUILD_TYPE=watcher and try making changes in the src directory and see them appear in the site.  I don't have an actual repro for the resetState error, so we'll just have to see if it stops happening.