### PR TITLE
moves pup into aside

### DIFF
--- a/src/components/new-stuff/new-stuff-prompt.js
+++ b/src/components/new-stuff/new-stuff-prompt.js
@@ -9,7 +9,7 @@ import NewStuffPup from './new-stuff-pup';
 import styles from './new-stuff-prompt.styl';
 
 const NewStuffPrompt = ({ onClick }) => (
-  <div className={styles.footer}>
+  <aside className={styles.footer}>
     <TooltipContainer
       align={['top']}
       persistent
@@ -22,7 +22,7 @@ const NewStuffPrompt = ({ onClick }) => (
       type="info"
       newStuff
     />
-  </div>
+  </aside>
 );
 
 NewStuffPrompt.propTypes = {


### PR DESCRIPTION
## Links
* none, lazy.
* https://app.clubhouse.io/glitch/story/4077/a11y-new-stuff-pup-should-be-contained-in-a-landmark-aside

## GIF/Screenshots:

## Changes:
* Puts pup into an aside

## Feedback I'm looking for:
Is this what we want, or should the _overlay_ be in the aside?
