### PR TITLE
separate and Title Case team and collection page titles

### DIFF
--- a/src/hooks/use-title-formatter.js
+++ b/src/hooks/use-title-formatter.js
@@ -1,0 +1,3 @@
+const useTitleFormatter = (title) => title.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1));
+
+export default useTitleFormatter;

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -16,6 +16,7 @@ import { useCurrentUser } from 'State/current-user';
 import { useCachedCollection } from 'State/api-cache';
 import { useCollectionEditor, userOrTeamIsAuthor } from 'State/collection';
 import useFocusFirst from 'Hooks/use-focus-first';
+import useTitleFormatter from 'Hooks/use-title-formatter';
 import { renderText } from 'Utils/markdown';
 import allCategories from 'Shared/categories';
 import { CDN_URL } from 'Utils/constants';
@@ -45,7 +46,7 @@ const CollectionPageContents = ({ collection: initialCollection }) => {
   return (
     <>
       <GlitchHelmet
-        title={collection.name.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1))}
+        title={useTitleFormatter(collection.name)}
         description={`${seoDescription} 🎏 A collection of apps by ${getCollectionOwnerName(collection)}`}
         canonicalUrl={getCollectionLink(collection)}
       />

--- a/src/presenters/pages/collection.js
+++ b/src/presenters/pages/collection.js
@@ -45,7 +45,7 @@ const CollectionPageContents = ({ collection: initialCollection }) => {
   return (
     <>
       <GlitchHelmet
-        title={collection.name}
+        title={collection.name.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1))}
         description={`${seoDescription} 🎏 A collection of apps by ${getCollectionOwnerName(collection)}`}
         canonicalUrl={getCollectionLink(collection)}
       />

--- a/src/presenters/pages/project.js
+++ b/src/presenters/pages/project.js
@@ -36,6 +36,7 @@ import {
 } from 'Models/project';
 import { getAllPages } from 'Shared/api';
 import useFocusFirst from 'Hooks/use-focus-first';
+import useTitleFormatter from 'Hooks/use-title-formatter';
 import { useAPIHandlers } from 'State/api';
 import { useCachedProject } from 'State/api-cache';
 import { tagline } from 'Utils/constants';
@@ -225,7 +226,7 @@ const ProjectPage = ({ project: initialProject }) => {
   return (
     <main id="main" aria-label="Glitch Project Page">
       <GlitchHelmet
-        title={project.domain.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1))}
+        title={useTitleFormatter(project.domain)}
         description={seoDescription}
         image={project.suspendedReason ? SUSPENDED_AVATAR_URL : getProjectAvatarUrl(project)}
         canonicalUrl={getProjectLink(project)}

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -146,7 +146,7 @@ function TeamPage({ team: initialTeam }) {
     <main className={styles.container} id="main" aria-label="Glitch Team Page">
       <section>
         <GlitchHelmet
-          title={team.name}
+          title={team.name.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1))}
           description={seoDescription}
           image={team.hasAvatarImage ? getTeamAvatarUrl(team) : null}
           canonicalUrl={getTeamLink(team)}

--- a/src/presenters/pages/team.js
+++ b/src/presenters/pages/team.js
@@ -27,6 +27,7 @@ import { useCurrentUser } from 'State/current-user';
 import { useNotifications } from 'State/notifications';
 import { useTeamEditor } from 'State/team';
 import useFocusFirst from 'Hooks/use-focus-first';
+import useTitleFormatter from 'Hooks/use-title-formatter';
 import { tagline } from 'Utils/constants';
 import { renderText } from 'Utils/markdown';
 import FilteredTag from 'Utils/filteredTag';
@@ -146,7 +147,7 @@ function TeamPage({ team: initialTeam }) {
     <main className={styles.container} id="main" aria-label="Glitch Team Page">
       <section>
         <GlitchHelmet
-          title={team.name.replace(/-/g, ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1))}
+          title={useTitleFormatter(team.name)}
           description={seoDescription}
           image={team.hasAvatarImage ? getTeamAvatarUrl(team) : null}
           canonicalUrl={getTeamLink(team)}


### PR DESCRIPTION
## Links
* https://cookie-ricotta.glitch.me
* https://app.clubhouse.io/glitch/story/7676/change-format-of-title-tags-for-team-and-collection-names

## GIF/Screenshots:
![Screen Shot 2020-01-22 at 2 19 35 PM](https://user-images.githubusercontent.com/3011231/72926441-6de30b80-3d22-11ea-88f8-d0bdb4b40ba9.png)
![Screen Shot 2020-01-22 at 2 20 15 PM](https://user-images.githubusercontent.com/3011231/72926446-6f143880-3d22-11ea-969a-b222bc6dce51.png)


## Changes:
* Separates words in team and collection domains (by hyphen only), converts them to Title Case

## How To Test:
* go to a team or collection page, see what's in the title bar

## Feedback I'm looking for:
we cool?