### PR TITLE
Quixotic rocket: Get rid of the lodash module replacement plugin to fix an optimizely error

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "if-env": "^1.0.4",
     "intersection-observer": "^0.7.0",
     "lodash": "^4.17.15",
-    "lodash-webpack-plugin": "^0.11.5",
     "markdown-it": "^9.0.1",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-github-headings": "^1.1.1",

--- a/server/optimizely.js
+++ b/server/optimizely.js
@@ -3,7 +3,7 @@ const { captureException } = require('@sentry/node');
 const dayjs = require('dayjs');
 const constants = require('./constants').current;
 
-export const optimizelyKey = process.env.OPTIMIZELY_KEY || constants.OPTIMIZELY_KEY;
+const optimizelyKey = process.env.OPTIMIZELY_KEY || constants.OPTIMIZELY_KEY;
 
 const optimizelyClient = createInstance({
   sdkKey: optimizelyKey,
@@ -38,6 +38,7 @@ const getOptimizelyId = (request, response) => {
 };
 
 module.exports = {
+  optimizelyKey,
   getOptimizelyClient,
   getOptimizelyData,
   getOptimizelyId,

--- a/server/optimizely.js
+++ b/server/optimizely.js
@@ -3,8 +3,10 @@ const { captureException } = require('@sentry/node');
 const dayjs = require('dayjs');
 const constants = require('./constants').current;
 
+export const optimizelyKey = process.env.OPTIMIZELY_KEY || constants.OPTIMIZELY_KEY;
+
 const optimizelyClient = createInstance({
-  sdkKey: process.env.OPTIMIZELY_KEY || constants.OPTIMIZELY_KEY,
+  sdkKey: optimizelyKey,
   datafileOptions: {
     autoUpdate: true,
     updateInterval: 60 * 1000, // check once per minute

--- a/server/routes.js
+++ b/server/routes.js
@@ -11,7 +11,7 @@ const webpackExpressMiddleware = require('./webpack');
 const constants = require('./constants');
 const { allByKeys } = require('../shared/api');
 const renderPage = require('./render');
-const { getOptimizelyData, getOptimizelyId } = require('./optimizely');
+const { getOptimizelyData, getOptimizelyId, optimizelyKey } = require('./optimizely');
 const { getHomeData, reloadHomeData, getPupdates, reloadPupdates, getZinePosts, reloadZinePosts } = require('./curated');
 
 module.exports = function(EXTERNAL_ROUTES) {
@@ -77,6 +77,7 @@ module.exports = function(EXTERNAL_ROUTES) {
       API_CACHE,
       EXTERNAL_ROUTES,
       HOME_CONTENT: getHomeData(),
+      OPTIMIZELY_KEY: optimizelyKey,
       OPTIMIZELY_DATA: getOptimizelyData(),
       OPTIMIZELY_ID: getOptimizelyId(req, res),
       PUPDATES_CONTENT: getPupdates(),

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -63,7 +63,6 @@ dependencies:
   if-env: 1.0.4
   intersection-observer: 0.7.0
   lodash: 4.17.15
-  lodash-webpack-plugin: 0.11.5
   markdown-it: 9.1.0
   markdown-it-emoji: 1.4.0
   markdown-it-github-headings: 1.1.2
@@ -6827,14 +6826,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  /lodash-webpack-plugin/0.11.5:
-    dependencies:
-      lodash: 4.17.15
-    dev: false
-    peerDependencies:
-      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
-    resolution:
-      integrity: sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==
   /lodash._arraypool/2.4.1:
     dev: false
     resolution:
@@ -11569,7 +11560,6 @@ specifiers:
   jsdom: ^15.1.1
   jsdom-global: ^3.0.2
   lodash: ^4.17.15
-  lodash-webpack-plugin: ^0.11.5
   markdown-it: ^9.0.1
   markdown-it-emoji: ^1.4.0
   markdown-it-github-headings: ^1.1.1

--- a/src/client.js
+++ b/src/client.js
@@ -11,7 +11,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import convertPlugin from 'Shared/dayjs-convert';
 import { configureScope, captureException } from 'Utils/sentry';
-import { EDITOR_URL, OPTIMIZELY_KEY } from 'Utils/constants';
+import { EDITOR_URL } from 'Utils/constants';
 import { GlobalsProvider } from 'State/globals';
 import { OptimizelyProvider } from 'State/rollouts';
 import App from './app';
@@ -42,7 +42,7 @@ window.bootstrap = async (container) => {
 
   // Now initalize the Optimizely sdk
   const optimizely = createInstance({
-    sdkKey: process.env.OPTIMIZELY_KEY || OPTIMIZELY_KEY,
+    sdkKey: window.OPTIMIZELY_KEY,
     datafile: window.OPTIMIZELY_DATA,
     datafileOptions: {
       autoUpdate: true,

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -44,6 +44,7 @@
       var SSR_SIGNED_IN = <%- SSR_SIGNED_IN %>;
       var SSR_HAS_PROJECTS = <%- SSR_HAS_PROJECTS %>;
       var SSR_IN_TESTING_TEAM = <%- SSR_IN_TESTING_TEAM %>;
+      var OPTIMIZELY_KEY = <%- JSON.stringify(OPTIMIZELY_KEY) %>;
       var OPTIMIZELY_DATA = <%- JSON.stringify(OPTIMIZELY_DATA) %>;
       var OPTIMIZELY_ID = <%- JSON.stringify(OPTIMIZELY_ID) %>;
       var BUILD_COMPLETE = <%- BUILD_COMPLETE %>;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,7 +154,7 @@ const browserConfig = {
   plugins: [
     // adding cloning fixes https://app.clubhouse.io/glitch/story/7590
     // adding shorthands fixes https://github.com/lodash/lodash/issues/3101
-    new LodashModuleReplacementPlugin({ cloning: true, shorthands: true }),
+    // new LodashModuleReplacementPlugin({ cloning: true, shorthands: true }),
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' }),
     new StatsPlugin('stats.json', {
       all: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,8 +151,8 @@ const browserConfig = {
       },
     ],
   },
-  plugins: [
-    new LodashModuleReplacementPlugin({ shorthands: true }), // adding shorthands fixes https://github.com/lodash/lodash/issues/3101
+  plugins: [// adding shorthands fixes https://github.com/lodash/lodash/issues/3101
+    new LodashModuleReplacementPlugin({ cloning: true, shorthands: true }), 
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' }),
     new StatsPlugin('stats.json', {
       all: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const AutoprefixerStylus = require('autoprefixer-stylus');
@@ -152,9 +151,6 @@ const browserConfig = {
     ],
   },
   plugins: [
-    // adding cloning fixes https://app.clubhouse.io/glitch/story/7590
-    // adding shorthands fixes https://github.com/lodash/lodash/issues/3101
-    // new LodashModuleReplacementPlugin({ cloning: true, shorthands: true }),
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' }),
     new StatsPlugin('stats.json', {
       all: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,8 +151,10 @@ const browserConfig = {
       },
     ],
   },
-  plugins: [// adding shorthands fixes https://github.com/lodash/lodash/issues/3101
-    new LodashModuleReplacementPlugin({ cloning: true, shorthands: true }), 
+  plugins: [
+    // adding cloning fixes https://app.clubhouse.io/glitch/story/7590
+    // adding shorthands fixes https://github.com/lodash/lodash/issues/3101
+    new LodashModuleReplacementPlugin({ cloning: true, shorthands: true }),
     new MiniCssExtractPlugin({ filename: '[name].[contenthash:8].css' }),
     new StatsPlugin('stats.json', {
       all: false,


### PR DESCRIPTION
## Links
https://quixotic-rocket.glitch.me/questions
https://app.clubhouse.io/glitch/story/7590/syntaxerror-json-parse-unexpected-character-at-line-1-column-1-of-the-json-data

## Changes:
- Send the optimizely key to the client rather than using process.env, which gets written into the bundle (so you don't have to wait for a rebuild after changing it)
- Removed the lodash module replacement plugin. It's supposed to cut file size by replacing unused lodash functions with identity/noop versions, but you have to specify which functions are preserved and it was breaking optimizely because it was replacing cloneDeep with an identity function.

## How To Test:
Check out the site and see if anything broke

## Feedback I'm looking for:
The bundle doesn't seem substantially larger, the difference is < 10kb. Am I looking at the wrong numbers? I think a slightly larger bundle is worth not having to deal with unrelated dependencies breaking because lodash isn't doing the thing it's supposed to do.