### PR TITLE
load empty script if pufferfish isn't enabled

### DIFF
--- a/src/state/glitch-pro.js
+++ b/src/state/glitch-pro.js
@@ -5,11 +5,12 @@ import { useFeatureEnabled } from 'State/rollouts';
 import { getUserLink } from 'Models/user';
 import useScript from 'Hooks/use-script';
 
-function useStripe() {
+function useStripe(pufferfishEnabled) {
   const [stripe, setStripe] = useState(null);
   const stripeJS = 'https://js.stripe.com/v3/';
 
-  const [loaded] = useScript(stripeJS);
+  const [loaded] = useScript(pufferfishEnabled ? stripeJS : '');
+
   useEffect(() => {
     if (loaded) {
       setStripe(window.Stripe('pk_test_WIJxKl0T1xT8zSb2StHu8zlo'));
@@ -20,8 +21,8 @@ function useStripe() {
 
 function useGlitchProState() {
   const { getSubscriptionStatus, createSubscriptionSession, cancelSubscription } = useAPIHandlers();
-  const stripe = useStripe();
   const userHasPufferfishEnabled = useFeatureEnabled('pufferfish');
+  const stripe = useStripe(userHasPufferfishEnabled);
 
   const { currentUser } = useCurrentUser();
   const [{ fetched, isActive, expiresAt }, setSubscriptionStatus] = useState({ fetched: false });


### PR DESCRIPTION
## Links
* https://breezy-ocelot.glitch.me
* https://app.clubhouse.io/glitch/story/7727/stripe-module-loading-on-every-page-adding-page-lag

## GIF/Screenshots:

## Changes:
* load a blank script if pufferfish isn't enabled, to save the time and data of loading stripe when we don't need it

## How To Test:
* enable/disable pufferfish, see what shows up in your debugger

## Feedback I'm looking for:
this feels hacky to me. is there a better way?
