### PR TITLE
fix team analytics page to use new rollouts hooks

### DIFF
--- a/src/components/team-analytics/index.js
+++ b/src/components/team-analytics/index.js
@@ -4,12 +4,13 @@ import dayjs from 'dayjs';
 import { cloneDeep, sumBy } from 'lodash';
 import sampleAnalytics, { sampleAnalyticsTime } from 'Curated/sample-analytics';
 import { Loader, SegmentedButton } from '@fogcreek/shared-components';
+import { useFeatureEnabled } from 'State/rollouts';
 
 import Text from 'Components/text/text';
 import { createAPIHook } from 'State/api';
 import { captureException } from 'Utils/sentry';
 
-import { useFeatureEnabledForEntity } from 'State/rollouts';
+
 import TeamAnalyticsTimePop from './team-analytics-time-pop';
 import TeamAnalyticsProjectPop from './team-analytics-project-pop';
 import SummaryItem from './team-analytics-summary';
@@ -79,7 +80,7 @@ function BannerMessage({ projects, featureEnabled }) {
 }
 
 function TeamAnalytics({ id, projects }) {
-  const featureEnabled = useFeatureEnabledForEntity('analytics', id);
+  const featureEnabled = useFeatureEnabled('analytics');
 
   const [activeFilter, setActiveFilter] = useState('views');
 


### PR DESCRIPTION
## GIF/Screenshots:
<img width="1341" alt="Screen Shot 2020-01-23 at 3 50 35 PM" src="https://user-images.githubusercontent.com/68270/73033858-2464f000-3df8-11ea-9b7b-8ac6e70dea64.png">

## Changes:
* Updates to use useFeatureEnabled, since it will either be enabled/disabled, not per team

## How To Test:
* Pull down locally and get the dev key from optimizely (keith can invite) and add that to your .env
* Go to a teams page, it should show a 
